### PR TITLE
Example should use json.dumps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ import json
 import arc
 
 def handler():
-  return {'body': json.dump(arc.reflect())}
+  return {'body': json.dumps(arc.reflect())}
 ```
 
 ### `arc`

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ pip install --target ./vendor architect-functions
 import json
 import arc
 
-def handler():
+def handler(event, context):
   return {'body': json.dumps(arc.reflect())}
 ```
 


### PR DESCRIPTION
`json.dump` writes to a filehandle and expects two arguments `json.dump(obj, fp)`.
`json.dumps` returns a string and expects one argument `json.dumps(obj)`

Another frustration is that, as a simple example, this did not have the right permissions to execute `ssm:GetParametersByPath`. 

I had to read a bunch of source and add an empty `@static` to my project to generate the necessary permission. I'm not sure what the right fix is there? Update the README?