### PR TITLE
Make sure that boto3 is installed when someone installs architect-functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,14 @@ from distutils.core import setup
 
 setup(
     name='architect-functions',
-    version='0.2.0',
+    version='0.2.1',
     packages=['arc'],
     url='https://github.com/arc-repos/arc-functions-python',
     license='Apache 2.0',
     author='Brian LeRoux',
     author_email='b@brian.io',
-    description='Runtime helpers for Architect provisioned AWS Lambda functions'
+    description='Runtime helpers for Architect provisioned AWS Lambda functions',
+    requires=[
+        'boto3',
+    ],
 )


### PR DESCRIPTION
In the current form, people would have to install boto3 manually to use `architect-functions`

This diff rectifies that