### PR TITLE
Initial implementation of jwe sessions in python

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,3 +11,4 @@ pytest-cov = "*"
 pep517 = "*"
 
 [packages]
+jwcrypto = "*"

--- a/arc/http.py
+++ b/arc/http.py
@@ -1,5 +1,0 @@
-def session_read():
-    return True
-
-def session_write():
-    return True

--- a/arc/http/__init__.py
+++ b/arc/http/__init__.py
@@ -1,0 +1,15 @@
+import os
+from .session.jwe import jwe_read, jwe_write
+
+def session_read(req):
+    if os.environ.get("SESSION_TABLE_NAME") == "jwe":
+        return jwe_read(req)
+
+    raise NotImplementedError()
+
+
+def session_write(payload):
+    if os.environ.get("SESSION_TABLE_NAME") == "jwe":
+        return jwe_write(payload)
+
+    raise NotImplementedError()

--- a/arc/http/session/jwe.py
+++ b/arc/http/session/jwe.py
@@ -1,0 +1,82 @@
+import math
+import os
+import time
+from http import cookies
+from typing import Any, Dict
+
+from jwcrypto import jwe, jwk
+from jwcrypto.common import base64url_encode, json_decode, json_encode
+
+COOKIE_NAME: str = "_idx"
+
+
+def _get_key() -> str:
+    # 32 bit key size
+    fallback = b"1234567890123456"
+
+    # need to STRONGLY encourage setting ARC_APP_SECRET in the docs
+    secret = os.environ.get("ARC_APP_SECRET", fallback)
+
+    return jwk.JWK(k=base64url_encode(secret), kty="oct")
+
+
+def _create_jwe(payload: Dict[Any, Any]) -> str:
+    payload = dict(payload)
+    payload["iat"] = math.floor(time.time())
+    jwetoken = jwe.JWE(
+        json_encode(payload),
+        json_encode({"alg": "dir", "enc": "A128GCM"}),
+        recipient=_get_key(),
+    )
+    return jwetoken.serialize(compact=True)
+
+
+def _parse_jwe(token: str) -> Dict[Any, Any]:
+    jwetoken = jwe.JWE()
+    jwetoken.deserialize(token, key=_get_key())
+    return json_decode(jwetoken.payload)
+
+
+def jwe_read(req) -> Dict[Any, Any]:
+    #
+    # reads req cookie and returns token payload or an empty object
+    #
+
+    # Lambda payload version 2 puts the cookies in an array on the request
+    if "cookies" in req:
+        raw_cookie = ";".join(req.get("cookies"))
+    else:
+        headers = req.get("headers", {})
+        # TODO: uppercase 'Cookie' is not the header name on AWS Lambda; it's
+        # lowercase 'cookie' on lambda...
+        raw_cookie = headers.get("Cookie", headers.get("cookie", ""))
+
+    jar = cookies.SimpleCookie(raw_cookie)
+    try:
+        parsed = _parse_jwe(jar.get(COOKIE_NAME).value)
+    except Exception as ex:
+        parsed = {}
+
+    return parsed
+
+
+#
+#  creates a Set-Cookie header with token payload encrypted
+#
+def jwe_write(payload: Dict[Any, Any]) -> str:
+    max_age = int(os.environ.get("SESSION_TTL", 7.884e8))
+
+    jar = cookies.SimpleCookie()
+    jar[COOKIE_NAME] = _create_jwe(payload)
+    jar[COOKIE_NAME]["max-age"] = max_age
+    jar[COOKIE_NAME]["expires"] = time.time() + max_age * 1000
+    jar[COOKIE_NAME]["httponly"] = True
+    jar[COOKIE_NAME]["path"] = "/"
+
+    if "SESSION_DOMAIN" in os.environ:
+        jar[COOKIE_NAME]["domain"] = os.environ.get("SESSION_DOMAIN")
+
+    if os.environ.get("NODE_ENV") != "testing":
+        jar[COOKIE_NAME]["secure"] = True
+
+    return jar.output(header='')

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ url = https://github.com/architect/functions-python
 [options]
 packages = find:
 install_requires =
+    jwcrypto
 
 [options.packages.find]
 include=arc

--- a/tests/test_http_sessions.py
+++ b/tests/test_http_sessions.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from arc.http import session_read, session_write
+from arc.http.session.jwe import _create_jwe, _parse_jwe
+
+
+def test_jwe_read_write():
+    payload = {"foo": {"bar": 123}, "yak": None}
+    token = _create_jwe(payload)
+    parsed = _parse_jwe(token)
+    del parsed["iat"]  # delete issued at timestamp
+    assert parsed == payload
+
+
+def test_jwe_cookies(monkeypatch):
+    monkeypatch.setenv("SESSION_TABLE_NAME", "jwe")
+    cookie = session_write({"count": 0})
+    mock = {
+        "headers": {
+            "cookie": cookie,
+        },
+    }
+
+    session = session_read(mock)
+    assert "count" in session
+    assert session["count"] == 0


### PR DESCRIPTION
I've implemented `arc.http.session_read` and `arc.http.session_write` when `SESSION_TABLE_NAME` === `jwe`.

This implementation is compatible with the code in https://github.com/architect/functions/blob/master/src/http/session/providers/jwe.js
 - my concern with the nodejs implementation is that the key isn't forced to be 128 bits

I have not tested it against the implementation in: https://github.com/architect/functions-ruby/blob/master/lib/architect/http.rb
 - my concern with the ruby implementation is that the fallback key is different than the nodejs version

Please let me know what you think! Thanks

 