### PR TITLE
Add ddb sessions

### DIFF
--- a/arc/http/__init__.py
+++ b/arc/http/__init__.py
@@ -1,24 +1,24 @@
 import os
 from .session.cookies import _write_cookie, _read_cookie
 from .session.jwe import jwe_read, jwe_write
+from .session.ddb import ddb_read, ddb_write
 
 COOKIE_NAME: str = "_idx"
+DEFAULT_SESSION_TABLE: str = "arc-sessions"
 
 
 def session_read(req):
-    if os.environ.get("SESSION_TABLE_NAME") == "jwe":
-        try:
-            cookie = _read_cookie(req, COOKIE_NAME)
-            return jwe_read(cookie)
-        except:
-            return {}
-
-    raise NotImplementedError()
+    table_name = os.environ.get("SESSION_TABLE_NAME", DEFAULT_SESSION_TABLE)
+    try:
+        cookie = _read_cookie(req, COOKIE_NAME)
+        return jwe_read(cookie) if table_name == "jwe" else ddb_read(cookie, table_name)
+    except:
+        return {}
 
 
 def session_write(payload):
-    if os.environ.get("SESSION_TABLE_NAME") == "jwe":
-        cookie = jwe_write(payload)
-        return _write_cookie(cookie, COOKIE_NAME)
-
-    raise NotImplementedError()
+    table_name = os.environ.get("SESSION_TABLE_NAME", DEFAULT_SESSION_TABLE)
+    cookie = (
+        jwe_write(payload) if table_name == "jwe" else ddb_write(payload, table_name)
+    )
+    return _write_cookie(cookie, COOKIE_NAME)

--- a/arc/http/__init__.py
+++ b/arc/http/__init__.py
@@ -1,16 +1,24 @@
 import os
+from .session.cookies import _write_cookie, _read_cookie
 from .session.jwe import jwe_read, jwe_write
+
+COOKIE_NAME: str = "_idx"
 
 
 def session_read(req):
     if os.environ.get("SESSION_TABLE_NAME") == "jwe":
-        return jwe_read(req)
+        try:
+            cookie = _read_cookie(req, COOKIE_NAME)
+            return jwe_read(cookie)
+        except:
+            return {}
 
     raise NotImplementedError()
 
 
 def session_write(payload):
     if os.environ.get("SESSION_TABLE_NAME") == "jwe":
-        return jwe_write(payload)
+        cookie = jwe_write(payload)
+        return _write_cookie(cookie, COOKIE_NAME)
 
     raise NotImplementedError()

--- a/arc/http/session/cookies.py
+++ b/arc/http/session/cookies.py
@@ -1,0 +1,38 @@
+import os
+import time
+from http import cookies
+from typing import Optional
+
+
+def _read_cookie(req, cookie_name: str) -> Optional[str]:
+    # Lambda payload version 2 puts the cookies in an array on the request
+    if "cookies" in req:
+        raw_cookie = ";".join(req.get("cookies"))
+    else:
+        headers = req.get("headers", {})
+        # TODO: uppercase 'Cookie' is not the header name on AWS Lambda; it's
+        # lowercase 'cookie' on lambda...
+        raw_cookie = headers.get("Cookie", headers.get("cookie", ""))
+
+    jar = cookies.SimpleCookie(raw_cookie)
+    cookie = jar.get(cookie_name)
+    return None if cookie is None else cookie.value
+
+
+def _write_cookie(payload: str, cookie_name: str) -> str:
+    max_age = int(os.environ.get("SESSION_TTL", 7.884e8))
+
+    jar = cookies.SimpleCookie()
+    jar[cookie_name] = payload
+    jar[cookie_name]["max-age"] = max_age
+    jar[cookie_name]["expires"] = time.time() + max_age * 1000
+    jar[cookie_name]["httponly"] = True
+    jar[cookie_name]["path"] = "/"
+
+    if "SESSION_DOMAIN" in os.environ:
+        jar[cookie_name]["domain"] = os.environ.get("SESSION_DOMAIN")
+
+    if os.environ.get("NODE_ENV") != "testing":
+        jar[cookie_name]["secure"] = True
+
+    return jar.output(header="")

--- a/arc/http/session/ddb.py
+++ b/arc/http/session/ddb.py
@@ -1,0 +1,66 @@
+import os
+from datetime import datetime, timedelta
+from base64 import b64encode, urlsafe_b64encode
+from typing import Any, Dict, Tuple, Optional
+from cryptography.hazmat.primitives import hashes, hmac
+from arc.tables import table
+
+
+def _get_secret() -> str:
+    return os.environ.get("ARC_APP_SECRET", os.environ.get("ARC_APP_NAME", "fallback"))
+
+
+def _sign(value: str, secret: str) -> str:
+    h = hmac.HMAC(secret.encode("utf-8"), hashes.SHA256())
+    h.update(value.encode("utf-8"))
+    digest = b64encode(h.finalize()).decode("utf-8").rstrip("=")
+    return value + "." + digest
+
+
+def _unsign(value: str, secret: str) -> Tuple[str, bool]:
+    where = value.rfind(".")
+    before, after = value[:where], value[where + 1 :]
+    return (before, _sign(before, secret) == value)
+
+
+def _week_from_now() -> int:
+    return int((datetime.now() + timedelta(weeks=1)).timestamp())
+
+
+def _uid_safe(byte_length: int) -> str:
+    buff = os.urandom(byte_length)
+    return urlsafe_b64encode(buff).decode("utf-8").rstrip("=")
+
+
+def ddb_read(cookie: Optional[str], table_name: str) -> Dict[Any, Any]:
+    db = table(table_name)
+
+    if cookie is not None:
+        secret = _get_secret()
+        cookie, valid = _unsign(cookie, secret)
+        if not valid:
+            cookie = None
+
+    # create a new session
+    if cookie is None:
+        session = {
+            "_idx": _uid_safe(18),
+            "_secret": _uid_safe(18),
+            "_ttl": _week_from_now(),
+        }
+        db.put_item(Item=session)
+        return session
+
+    session = db.get_item(Key={"_idx": cookie}, ConsistentRead=True)
+    return session.get("Item", {})
+
+
+def ddb_write(payload: Dict[Any, Any], table_name: str) -> str:
+    payload = dict(payload)
+    payload["_ttl"] = _week_from_now()
+
+    db = table(table_name)
+    db.put_item(Item=payload)
+
+    secret = _get_secret()
+    return _sign(payload.get("_idx"), secret)

--- a/arc/http/session/jwe.py
+++ b/arc/http/session/jwe.py
@@ -1,13 +1,10 @@
 import math
 import os
 import time
-from http import cookies
 from typing import Any, Dict
 
 from jwcrypto import jwe, jwk
 from jwcrypto.common import base64url_encode, json_decode, json_encode
-
-COOKIE_NAME: str = "_idx"
 
 
 def _get_key() -> str:
@@ -20,7 +17,13 @@ def _get_key() -> str:
     return jwk.JWK(k=base64url_encode(secret), kty="oct")
 
 
-def _create_jwe(payload: Dict[Any, Any]) -> str:
+def jwe_read(cookie: str) -> Dict[Any, Any]:
+    jwetoken = jwe.JWE()
+    jwetoken.deserialize(cookie, key=_get_key())
+    return json_decode(jwetoken.payload)
+
+
+def jwe_write(payload: Dict[Any, Any]) -> str:
     payload = dict(payload)
     payload["iat"] = math.floor(time.time())
     jwetoken = jwe.JWE(
@@ -29,54 +32,3 @@ def _create_jwe(payload: Dict[Any, Any]) -> str:
         recipient=_get_key(),
     )
     return jwetoken.serialize(compact=True)
-
-
-def _parse_jwe(token: str) -> Dict[Any, Any]:
-    jwetoken = jwe.JWE()
-    jwetoken.deserialize(token, key=_get_key())
-    return json_decode(jwetoken.payload)
-
-
-def jwe_read(req) -> Dict[Any, Any]:
-    #
-    # reads req cookie and returns token payload or an empty object
-    #
-
-    # Lambda payload version 2 puts the cookies in an array on the request
-    if "cookies" in req:
-        raw_cookie = ";".join(req.get("cookies"))
-    else:
-        headers = req.get("headers", {})
-        # TODO: uppercase 'Cookie' is not the header name on AWS Lambda; it's
-        # lowercase 'cookie' on lambda...
-        raw_cookie = headers.get("Cookie", headers.get("cookie", ""))
-
-    jar = cookies.SimpleCookie(raw_cookie)
-    try:
-        parsed = _parse_jwe(jar.get(COOKIE_NAME).value)
-    except Exception as ex:
-        parsed = {}
-
-    return parsed
-
-
-#
-#  creates a Set-Cookie header with token payload encrypted
-#
-def jwe_write(payload: Dict[Any, Any]) -> str:
-    max_age = int(os.environ.get("SESSION_TTL", 7.884e8))
-
-    jar = cookies.SimpleCookie()
-    jar[COOKIE_NAME] = _create_jwe(payload)
-    jar[COOKIE_NAME]["max-age"] = max_age
-    jar[COOKIE_NAME]["expires"] = time.time() + max_age * 1000
-    jar[COOKIE_NAME]["httponly"] = True
-    jar[COOKIE_NAME]["path"] = "/"
-
-    if "SESSION_DOMAIN" in os.environ:
-        jar[COOKIE_NAME]["domain"] = os.environ.get("SESSION_DOMAIN")
-
-    if os.environ.get("NODE_ENV") != "testing":
-        jar[COOKIE_NAME]["secure"] = True
-
-    return jar.output(header="")

--- a/tests/test_http_sessions.py
+++ b/tests/test_http_sessions.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from arc.http import session_read, session_write
 from arc.http.session.jwe import jwe_write, jwe_read
+from arc.http.session.ddb import ddb_write, ddb_read
+from arc.http.session.ddb import _sign, _unsign
 
 
 def test_jwe_read_write():
@@ -11,7 +13,7 @@ def test_jwe_read_write():
     assert parsed == payload
 
 
-def test_jwe_cookies(monkeypatch):
+def test_jwe_session(monkeypatch):
     monkeypatch.setenv("SESSION_TABLE_NAME", "jwe")
     cookie = session_write({"count": 0})
     mock = {
@@ -23,3 +25,39 @@ def test_jwe_cookies(monkeypatch):
     session = session_read(mock)
     assert "count" in session
     assert session["count"] == 0
+
+
+def test_ddb_sign_unsign():
+    original = "123456"
+    secret = "1234567890"
+    signed = _sign(original, secret)
+    unsigned, valid = _unsign(signed, secret)
+    assert valid == True
+    assert original == unsigned
+
+
+def test_ddb_sign_unsign_fail():
+    original = "123456"
+    secret = "1234567890"
+    signed = _sign(original, secret)
+    unsigned, valid = _unsign(signed, secret + "1234")
+    assert valid == False
+
+
+def test_jwe_read_write(arc_reflection, ddb_client):
+    tablename = "sessions"
+    ddb_client.create_table(
+        TableName=tablename,
+        KeySchema=[{"AttributeName": "_idx", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "_idx", "AttributeType": "S"},
+        ],
+    )
+    tables = ddb_client.list_tables()
+    arc_reflection(params={f"tables/{tablename}": tables["TableNames"][0]})
+
+    payload = {"_idx": "abc", "foo": {"bar": 123}, "yak": None}
+    token = ddb_write(payload, tablename)
+    parsed = ddb_read(token, tablename)
+    del parsed["_ttl"]  # delete ttl timestamp
+    assert parsed == payload

--- a/tests/test_http_sessions.py
+++ b/tests/test_http_sessions.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from arc.http import session_read, session_write
-from arc.http.session.jwe import _create_jwe, _parse_jwe
+from arc.http.session.jwe import jwe_write, jwe_read
 
 
 def test_jwe_read_write():
     payload = {"foo": {"bar": 123}, "yak": None}
-    token = _create_jwe(payload)
-    parsed = _parse_jwe(token)
+    token = jwe_write(payload)
+    parsed = jwe_read(token)
     del parsed["iat"]  # delete issued at timestamp
     assert parsed == payload
 


### PR DESCRIPTION
I've implemented this to interoperate with the nodejs ddb session support.
 - requires a dynamodb table with a _idx string key and a _ttl number attribute 
 - reimplements csrf Tokens.secret, uid-safe base64 uids-from-random-bytes, and cookie-signature sign/unsign w/ SHA256 HMAC.

