### PR TITLE
Use python-jose, for a pure-python jwe implementation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,4 +12,4 @@ build = "*"
 black = "==20.8b1"
 
 [packages]
-jwcrypto = "*"
+python-jose = {editable = true, git = "https://github.com/mpdavis/python-jose.git", ref = "master"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ url = https://github.com/architect/functions-python
 [options]
 packages = find:
 install_requires =
-    jwcrypto
+    python-jose @ https://github.com/mpdavis/python-jose/archive/master.zip#egg=python-jose
 
 [options.packages.find]
 include=arc*


### PR DESCRIPTION
jwcrypto required cryptography, which needed to be built for amazon linux