### PR TITLE
Ensure unknown sessions create a new session instead of returning an empty dict

### DIFF
--- a/arc/http/helpers/res_fmt.py
+++ b/arc/http/helpers/res_fmt.py
@@ -2,7 +2,7 @@ import gzip
 from base64 import b64encode
 import simplejson as _json
 
-from arc.http.session import session_write
+from arc.http.session import session_read, session_write
 from .binary_types import binary_types
 
 
@@ -223,6 +223,12 @@ def res(req, params):
 
     # Save the passed session
     if params.get("session"):
-        res["headers"]["set-cookie"] = session_write(params["session"])
+        sesh = params["session"]
+        if not sesh.get("_idx"):
+            session = session_read(req)
+            session.update(params["session"])
+            sesh = session
+
+        res["headers"]["set-cookie"] = session_write(sesh)
 
     return res

--- a/tests/test_http_sessions.py
+++ b/tests/test_http_sessions.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import urllib.parse
 import jose
 import pytest
 import arc
@@ -72,6 +73,18 @@ def test_ddb_session(monkeypatch, arc_services, ddb_client):
     mock = {
         "headers": {
             "cookie": cookie,
+        }
+    }
+    session = arc.http.session_read(mock)
+    assert "count" in session
+    assert session["count"] == 0
+
+    # Ensure URI encoding (inbound from API Gateway) doesn't break cookie validation
+    idx = cookie.split(";")[0][6:]  # Strip `_idx=`
+    encoded_cookie = "_idx=" + urllib.parse.quote(idx)
+    mock = {
+        "headers": {
+            "cookie": encoded_cookie,
         },
     }
     session = arc.http.session_read(mock)


### PR DESCRIPTION
Automatically read / merge request session if `session` property is passed via `http.res` Fix cookie digest URI encoding bug

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
