### PR TITLE
Ensure FIFO queues get `MessageGroupId` parameter in `queues.publish()`

### DIFF
--- a/arc/queues/__init__.py
+++ b/arc/queues/__init__.py
@@ -1,5 +1,7 @@
 import json
+import os
 import urllib.request
+import uuid
 import boto3
 from arc.services import _services
 from arc._lib import use_aws, get_ports
@@ -37,8 +39,13 @@ def publish(name, payload):
             _sqs_client_cache = boto3.client("sqs")
 
         def pub(arn):
+            stack = os.environ.get("ARC_STACK_NAME")
             return _sqs_client_cache.send_message(
-                QueueUrl=arn, MessageBody=json.dumps(payload), DelaySeconds=0
+                QueueUrl=arn,
+                MessageBody=json.dumps(payload),
+                DelaySeconds=0,
+                MessageGroupId=stack,
+                MessageDeduplicationId=str(uuid.uuid4()),
             )
 
         if _queues_cache.get(name):

--- a/tests/test_queues.py
+++ b/tests/test_queues.py
@@ -25,7 +25,9 @@ def test_parse():
 
 def test_queue_publish(arc_services, sqs_client):
     queue_name = "continuum"
-    sqs_client.create_queue(QueueName=queue_name)
+    sqs_client.create_queue(
+        QueueName=queue_name + ".fifo", Attributes={"FifoQueue": "true"}
+    )
     queues = sqs_client.list_queues()
 
     arc_services(params={f"queues/{queue_name}": queues["QueueUrls"][0]})


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
