### PR TITLE
Add missing boto3 dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,5 +12,6 @@ build = "*"
 black = "*"
 
 [packages]
+boto3 = "*"
 python-jose = "*"
 simplejson = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Runtime utility library for Functional Web Apps (FWAs) built with
 readme = "readme_pypi.md"
 requires-python = ">=3.7"
 dependencies = [
+    "boto3",
     "cryptography",
     "python-jose",
     "simplejson",


### PR DESCRIPTION
`functions-python` seems to assume that `boto3` is installed already, and does not have it as a dependency in either the `pyproject.toml` or `Pipfile` file. 

As `boto3` is a dependency, this pull request adds it.